### PR TITLE
Update Helpers.cs

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -968,14 +968,21 @@ namespace DotNetNuke.Modules.Repository
             DownloadAs = DownloadAs.Replace(" ", "_");
 
             System.IO.FileInfo objFile = new System.IO.FileInfo(FilePath);
-            System.Web.HttpResponse objResponse = System.Web.HttpContext.Current.Response;
-            objResponse.ClearContent();
-            objResponse.ClearHeaders();
+            
+            var b = File.ReadAllBytes(FilePath);
 
-            objResponse.AppendHeader("Content-Type", MimeMapping.GetMimeMapping(objFile.Extension));
-            objResponse.AppendHeader("Content-Disposition", "attachment; filename=" + DownloadAs);
-            objResponse.AppendHeader("Content-Length", objFile.Length.ToString());
-            objResponse.TransmitFile(objFile.FullName);
+	    var Response = System.Web.HttpContext.Current.Response;
+
+            Response.Clear();            
+            Response.ContentType = MimeMapping.GetMimeMapping(objFile.Extension);
+            Response.AppendHeader("Content-Disposition", "attachment; filename=" + DownloadAs);
+            Response.AddHeader("Content-Length", b.Length.ToString());
+            Response.Flush();
+            Response.BinaryWrite(b);
+
+            HttpContext.Current.Response.Flush();
+            HttpContext.Current.Response.SuppressContent = true;
+            HttpContext.Current.ApplicationInstance.CompleteRequest();
         }
 
 		#endregion


### PR DESCRIPTION
Fix issue #55 for extra data appended to end of downloaded file

<!-- 
This is the code I've always used for file downloads in ASP.Net.  I'm unclear why the original code, which calls a native Response method, misbehaves.  I do know this code hasn't failed me to date.  

Although I suggest wrapping it in a try/catch, as if the user cancels the download dialog it throws an exception in the module.
-->

### Description of PR...


## Changes made
- ReWrote StreamFile.



## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #55