### PR TITLE
Fixed an issue where the admin message would show without description

### DIFF
--- a/Repository.ascx.cs
+++ b/Repository.ascx.cs
@@ -12,6 +12,8 @@ using System;
 using System.Collections;
 using System.Data;
 using System.IO;
+using System.Linq;
+
 //
 // DotNetNuke® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2005
@@ -281,21 +283,7 @@ namespace DotNetNuke.Modules.Repository
                 objModules.UpdateModuleSetting(ModuleId, "useridupgrade", "true");
             }
 
-            try
-            {
-                if (Settings["description"] != null)
-                {
-                    lblDescription.Text = Server.HtmlDecode(Convert.ToString(Settings["description"]));
-                }
-                else
-                {
-                    lblDescription.Text = (Localization.GetString("InitialMessage", LocalResourceFile));
-                }
-            }
-            catch (Exception ex)
-            {
-                lblDescription.Text = (Localization.GetString("InitialMessage", LocalResourceFile));
-            }
+            lblDescription.Text = this.GetDescription();
 
             try
             {
@@ -435,6 +423,20 @@ namespace DotNetNuke.Modules.Repository
 
         }
 
+        private string GetDescription()
+        {
+            if (Settings.ContainsKey("description"))
+            {
+                return Server.HtmlDecode(Convert.ToString(Settings["description"]));
+            }
+
+            if (!Settings.ContainsKey("initialized") || Convert.ToBoolean(Settings["initialized"]) == false)
+            {
+                return this.UserInfo.IsInRole(PortalSettings.AdministratorRoleName) ? Localization.GetString("InitialMessage", LocalResourceFile) : string.Empty;
+            }            
+
+            return string.Empty;
+        }
 
         private void lstObjects_ItemCreated(object sender, System.Web.UI.WebControls.DataGridItemEventArgs e)
         {

--- a/Settings.ascx.cs
+++ b/Settings.ascx.cs
@@ -1044,6 +1044,7 @@ namespace DotNetNuke.Modules.Repository
                 objModules.UpdateModuleSetting(ModuleId, "template", cboTemplate.SelectedItem.Value);
                 objModules.UpdateModuleSetting(ModuleId, "datacontrol", rblDataControl.SelectedValue);
                 objModules.UpdateModuleSetting(ModuleId, "ratingsimages", cboRatingsImages.SelectedItem.Value);
+                objModules.UpdateModuleSetting(ModuleId, "initialized", true.ToString());
 
                 string ModerationRoles = ";";
                 foreach (ListItem item_loopVariable in chkModerationRoles.Items)


### PR DESCRIPTION
1. The admin message would show to non-admins, this can now only show if the acting user is the admin
2. Now a module is allowed to not have a description, the logic is based on first saving of settings instead of being based on the description.

Closes #74

