### PR TITLE
Fixed the management of the "no image" setting

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -513,6 +513,11 @@ namespace DotNetNuke.Modules.Repository
                 Directory.CreateDirectory(g_ApprovedFolder);
                 // copy the noimage graphic to the newly created folder.
                 File.Copy(HttpContext.Current.Server.MapPath("~/DesktopModules/Repository/images/noimage.jpg"), g_ApprovedFolder + "\\noimage.jpg");
+                if (g_ApprovedFolder.StartsWith(_portalSettings.HomeDirectoryMapPath))
+                {
+                    string relativeApprovedFolderPath = g_ApprovedFolder.Substring(_portalSettings.HomeDirectoryMapPath.Length);
+                    FolderManager.Instance.Synchronize(_PortalID, relativeApprovedFolderPath);
+                }
             }
 
             // and make sure the Pending folder exists

--- a/MakeThumbnail.aspx.cs
+++ b/MakeThumbnail.aspx.cs
@@ -163,7 +163,18 @@ namespace DotNetNuke.Modules.Repository
 					strPathToImage = noImageURL;
 					bIsURL = true;
 				} else {
-					strPathToImage = Server.MapPath(_portalSettings.HomeDirectory + noImageURL);
+					string g_ApprovedFolder = "";
+                    if (!string.IsNullOrEmpty(Convert.ToString(settings["folderlocation"])) &&
+						settings["folderlocation"].ToString() != PortalSettings.Current.HomeDirectoryMapPath + oRepositoryBusinessController.DefaultFolderLocationSubPath)
+                    {
+                        g_ApprovedFolder = settings["folderlocation"].ToString();
+                    }
+                    else
+                    {
+                        g_ApprovedFolder = _portalSettings.HomeDirectoryMapPath;
+                    }
+
+                    strPathToImage = g_ApprovedFolder + noImageURL.Replace("/", "\\");
 				}
 			}
 

--- a/Settings.ascx.cs
+++ b/Settings.ascx.cs
@@ -909,19 +909,14 @@ namespace DotNetNuke.Modules.Repository
                         FileLocationRow5.Visible = true;
                     }
 
-                    // make sure that the default noimage.jpg file exists in the default Portal folder
-                    if (!File.Exists(Server.MapPath(_portalSettings.HomeDirectory + "noimage.jpg")))
-                    {
-                        File.Copy(Server.MapPath("~/DesktopModules/Repository/images/noimage.jpg"), Server.MapPath(_portalSettings.HomeDirectory + "noimage.jpg"));
-                    }
-
+                    ctlURL.FileFilter = Common.Globals.ImageFileTypes;
                     if (!string.IsNullOrEmpty(Convert.ToString(settings["noimage"])))
                     {
                         ctlURL.Url = Convert.ToString(settings["noimage"]);
                     }
                     else
                     {
-                        ctlURL.Url = "noImage.jpg";
+                        ctlURL.Url = busController.DefaultFolderLocationSubPath + "/noImage.jpg";
                     }
 
                     // Localization


### PR DESCRIPTION
### Fixed the management of the "no image" setting. It mainly concerns the default file copy in the module initialization.


## Changes made
- Added ApprovedFolder filesystem synchronization for "noimage" setting management.
- Complete the thumbnail manager to work with customized folders on old modules.
- Removed obsolete "noimage.jpg" copy in the settings form.


## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other

Close #88 