### PR TITLE
Fixed an html encoding issue

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -860,11 +860,11 @@ namespace DotNetNuke.Modules.Repository
                 DotNetNuke.UI.WebControls.TreeNode newNode = new DotNetNuke.UI.WebControls.TreeNode();
                 if (showCount)
                 {
-                    newNode.Text = cat.Category + "(" + cat.Count.ToString() + ")";
+                    newNode.Text = WebUtility.HtmlEncode(cat.Category) + "(" + cat.Count.ToString() + ")";
                 }
                 else
                 {
-                    newNode.Text = cat.Category;
+                    newNode.Text = WebUtility.HtmlEncode(cat.Category);
                 }
                 newNode.Key = cat.ItemId.ToString();
                 newNode.ToolTip = "";
@@ -1494,11 +1494,11 @@ namespace DotNetNuke.Modules.Repository
             // ------------------------------------------------------------------
 
             objRepository.ItemId = pRepository.ItemId;
-            objRepository.Name = WebUtility.HtmlEncode(pRepository.Name);
-            objRepository.Description = objSecurity.InputFilter(pRepository.Description, PortalSecurity.FilterFlag.NoScripting);
-            objRepository.Summary = objSecurity.InputFilter(pRepository.Summary, PortalSecurity.FilterFlag.NoScripting);
-            objRepository.Author = WebUtility.HtmlEncode(pRepository.Author);
-            objRepository.AuthorEMail = WebUtility.HtmlEncode(pRepository.AuthorEMail);
+            objRepository.Name = HtmlUtils.StripTags(pRepository.Name, false);
+            objRepository.Description = HtmlUtils.SanitizeHtmlIfNeeded(System.Web.HttpUtility.HtmlDecode(pRepository.Description), false);
+            objRepository.Summary = HtmlUtils.SanitizeHtmlIfNeeded(System.Web.HttpUtility.HtmlDecode(pRepository.Summary), false);
+            objRepository.Author = HtmlUtils.StripTags(pRepository.Author, false);
+            objRepository.AuthorEMail = HtmlUtils.StripTags(pRepository.AuthorEMail, false);
             objRepository.CreatedByUser = userInfo.UserID.ToString();
             objRepository.ModuleId = _ModuleID;
             objRepository.PreviewImage = "";

--- a/Repository.ascx.cs
+++ b/Repository.ascx.cs
@@ -527,7 +527,6 @@ namespace DotNetNuke.Modules.Repository
 
         public void lstObjects_ItemCommand(object source, DataGridCommandEventArgs e)
         {
-            DotNetNuke.Security.PortalSecurity objSecurity = new DotNetNuke.Security.PortalSecurity();
             PlaceHolder objPlaceHolder = (PlaceHolder)e.Item.Cells[0].FindControl("PlaceHolder");
             HtmlTable objCommentTable = (HtmlTable)e.Item.Cells[0].FindControl("tblComments");
 
@@ -785,7 +784,6 @@ namespace DotNetNuke.Modules.Repository
 
         private void DataList1_ItemCommand(object source, System.Web.UI.WebControls.DataListCommandEventArgs e)
         {
-            DotNetNuke.Security.PortalSecurity objSecurity = new DotNetNuke.Security.PortalSecurity();
             PlaceHolder objPlaceHolder = (PlaceHolder)e.Item.FindControl("PlaceHolder1");
             HtmlTable objCommentTable = (HtmlTable)e.Item.FindControl("tblComments");
 
@@ -977,7 +975,6 @@ namespace DotNetNuke.Modules.Repository
             RepositoryAttributeValuesInfo value = null;
             RepositoryObjectValuesController objectValues = new RepositoryObjectValuesController();
             RepositoryObjectValuesInfo objectValue = null;
-            DotNetNuke.Security.PortalSecurity objSecurity = new DotNetNuke.Security.PortalSecurity();
 
             objRepository = new RepositoryInfo();
             objRepository = dataItem as RepositoryInfo;
@@ -1320,12 +1317,12 @@ namespace DotNetNuke.Modules.Repository
                                             case "DESCRIPTION":
                                                 if (bRaw)
                                                 {
-                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(objRepository.Description, PortalSecurity.FilterFlag.NoScripting)));
+                                                    objPlaceHolder.Controls.Add(new LiteralControl(HtmlUtils.SanitizeHtmlIfNeeded(objRepository.Description, false)));
                                                 }
                                                 else
                                                 {
                                                     Label objDescriptionLabel = new Label();
-                                                    objDescriptionLabel.Text = objSecurity.InputFilter(objRepository.Description, PortalSecurity.FilterFlag.NoScripting);
+                                                    objDescriptionLabel.Text = HtmlUtils.SanitizeHtmlIfNeeded(objRepository.Description, false);
                                                     objDescriptionLabel.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "DESCRIPTION", "CssClass", "normal");
                                                     objPlaceHolder.Controls.Add(objDescriptionLabel);
                                                 }
@@ -1333,12 +1330,12 @@ namespace DotNetNuke.Modules.Repository
                                             case "SUMMARY":
                                                 if (bRaw)
                                                 {
-                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(objRepository.Summary, PortalSecurity.FilterFlag.NoScripting)));
+                                                    objPlaceHolder.Controls.Add(new LiteralControl(HtmlUtils.SanitizeHtmlIfNeeded(objRepository.Summary, false)));
                                                 }
                                                 else
                                                 {
                                                     Label objSummaryLabel = new Label();
-                                                    objSummaryLabel.Text = objSecurity.InputFilter(objRepository.Summary, PortalSecurity.FilterFlag.NoScripting);
+                                                    objSummaryLabel.Text = HtmlUtils.SanitizeHtmlIfNeeded(objRepository.Summary, false);
                                                     objSummaryLabel.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "SUMMARY", "CssClass", "normal");
                                                     objPlaceHolder.Controls.Add(objSummaryLabel);
                                                 }

--- a/Repository.ascx.cs
+++ b/Repository.ascx.cs
@@ -619,11 +619,9 @@ namespace DotNetNuke.Modules.Repository
                     objCommentsPanel = (Panel)e.Item.Cells[0].FindControl("pnlComments");
                     txtName = (TextBox)objCommentsPanel.FindControl("txtUserName");
                     txtComment = (TextBox)objCommentsPanel.FindControl("txtComment");
-                    txtName.Text = WebUtility.HtmlEncode(txtName.Text);
-                    txtComment.Text = WebUtility.HtmlEncode(txtComment.Text);
                     if (txtName.Text.Length > 0 & txtComment.Text.Length > 0)
                     {
-                        repositoryComments.AddRepositoryComment(objRepository.ItemId, ModuleId, txtName.Text, txtComment.Text);
+                        repositoryComments.AddRepositoryComment(objRepository.ItemId, ModuleId, HtmlUtils.StripTags(txtName.Text, false), HtmlUtils.StripTags(txtComment.Text, false));
                         SendCommentNotification(objRepository, txtName, txtComment);
                     }
                     b_CommentsIsVisible = false;
@@ -894,11 +892,9 @@ namespace DotNetNuke.Modules.Repository
                     objCommentsPanel = (Panel)objPlaceHolder.FindControl("pnlComments");
                     txtName = (TextBox)objCommentsPanel.FindControl("txtUserName");
                     txtComment = (TextBox)objCommentsPanel.FindControl("txtComment");
-                    txtName.Text = WebUtility.HtmlEncode(txtName.Text);
-                    txtComment.Text = WebUtility.HtmlEncode(txtComment.Text);
                     if (txtName.Text.Length > 0 & txtComment.Text.Length > 0)
                     {
-                        repositoryComments.AddRepositoryComment(objRepository.ItemId, ModuleId, txtName.Text, txtComment.Text);
+                        repositoryComments.AddRepositoryComment(objRepository.ItemId, ModuleId, HtmlUtils.StripTags(txtName.Text, false), HtmlUtils.StripTags(txtComment.Text, false));
                         SendCommentNotification(objRepository, txtName, txtComment);
                     }
                     System.Collections.Generic.List<RepositoryInfo> items = new System.Collections.Generic.List<RepositoryInfo>();
@@ -1245,12 +1241,12 @@ namespace DotNetNuke.Modules.Repository
                                                 }
                                                 if (bRaw)
                                                 {
-                                                    objPlaceHolder.Controls.Add(new LiteralControl(sCat));
+                                                    objPlaceHolder.Controls.Add(new LiteralControl(WebUtility.HtmlEncode(sCat)));
                                                 }
                                                 else
                                                 {
                                                     Label objCategoryLabel = new Label();
-                                                    objCategoryLabel.Text = sCat;
+                                                    objCategoryLabel.Text = WebUtility.HtmlEncode(sCat);
                                                     objCategoryLabel.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "CssClass", "Head");
                                                     objPlaceHolder.Controls.Add(objCategoryLabel);
                                                 }
@@ -1263,7 +1259,7 @@ namespace DotNetNuke.Modules.Repository
                                                 foreach (RepositoryObjectCategoriesInfo item in categoryController.GetRepositoryObjectCategories(objRepository.ItemId))
                                                 {
                                                     objCategory = categories.GetSingleRepositoryCategory(item.CategoryID);
-                                                    sCategories.Append(objCategory.Category + ",");
+                                                    sCategories.Append(WebUtility.HtmlEncode(objCategory.Category) + ",");
                                                 }
 
                                                 if (bRaw)
@@ -1324,12 +1320,12 @@ namespace DotNetNuke.Modules.Repository
                                             case "DESCRIPTION":
                                                 if (bRaw)
                                                 {
-                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(Server.HtmlDecode(objRepository.Description), PortalSecurity.FilterFlag.NoScripting)));
+                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(objRepository.Description, PortalSecurity.FilterFlag.NoScripting)));
                                                 }
                                                 else
                                                 {
                                                     Label objDescriptionLabel = new Label();
-                                                    objDescriptionLabel.Text = objSecurity.InputFilter(Server.HtmlDecode(objRepository.Description), PortalSecurity.FilterFlag.NoScripting);
+                                                    objDescriptionLabel.Text = objSecurity.InputFilter(objRepository.Description, PortalSecurity.FilterFlag.NoScripting);
                                                     objDescriptionLabel.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "DESCRIPTION", "CssClass", "normal");
                                                     objPlaceHolder.Controls.Add(objDescriptionLabel);
                                                 }
@@ -1337,12 +1333,12 @@ namespace DotNetNuke.Modules.Repository
                                             case "SUMMARY":
                                                 if (bRaw)
                                                 {
-                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(Server.HtmlDecode(objRepository.Summary), PortalSecurity.FilterFlag.NoScripting)));
+                                                    objPlaceHolder.Controls.Add(new LiteralControl(objSecurity.InputFilter(objRepository.Summary, PortalSecurity.FilterFlag.NoScripting)));
                                                 }
                                                 else
                                                 {
                                                     Label objSummaryLabel = new Label();
-                                                    objSummaryLabel.Text = objSecurity.InputFilter(Server.HtmlDecode(objRepository.Summary), PortalSecurity.FilterFlag.NoScripting);
+                                                    objSummaryLabel.Text = objSecurity.InputFilter(objRepository.Summary, PortalSecurity.FilterFlag.NoScripting);
                                                     objSummaryLabel.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "SUMMARY", "CssClass", "normal");
                                                     objPlaceHolder.Controls.Add(objSummaryLabel);
                                                 }

--- a/RepositoryDashboard.ascx.cs
+++ b/RepositoryDashboard.ascx.cs
@@ -6,6 +6,7 @@ using DotNetNuke.UI.WebControls;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections;
+using System.Net;
 //
 // DotNetNuke® - http://www.dotnetnuke.com
 // Copyright (c) 2002-2005
@@ -929,12 +930,12 @@ namespace DotNetNuke.Modules.Repository
 			// -- check the download roles
 			LinkButton objLinkButton = new LinkButton();
 			objLinkButton.ID = "hypDownload";
-			objLinkButton.Text = objItem.Author.ToString();
+			objLinkButton.Text = WebUtility.HtmlEncode(objItem.Author.ToString());
 			objLinkButton.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "AUTHOR", "CssClass", "SubHead");
 			objLinkButton.CommandName = "SelectAuthor";
 			objLinkButton.CommandArgument = objItem.Author.ToString();
 			objLinkButton.EnableViewState = true;
-			objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + objItem.Author.ToString());
+			objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + WebUtility.HtmlEncode(objItem.Author.ToString()));
 			objPlaceHolder.Controls.Add(objLinkButton);
 		}
 
@@ -946,7 +947,7 @@ namespace DotNetNuke.Modules.Repository
 					LinkButton objLinkButton = new LinkButton();
 					objLinkButton.ID = "hypDownload";
 					if (isFileName) {
-						objLinkButton.Text = objItem.Name.ToString();
+						objLinkButton.Text = WebUtility.HtmlEncode(objItem.Name.ToString());
 						if (oRepositoryBusinessController.IsURL(objItem.FileName)) {
 							objLinkButton.ToolTip = Localization.GetString("ClickToDownload", LocalResourceFile);
 						} else {
@@ -978,14 +979,14 @@ namespace DotNetNuke.Modules.Repository
 			} else {
 				LinkButton objLinkButton = new LinkButton();
 				objLinkButton.ID = "hypDownload";
-				objLinkButton.Text = objItem.Name.ToString();
+				objLinkButton.Text = WebUtility.HtmlEncode(objItem.Name.ToString());
 				objLinkButton.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "FILENAME", "CssClass", "normal");
 				objLinkButton.EnableViewState = true;
-				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + objItem.Name.ToString());
+				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + WebUtility.HtmlEncode(objItem.Name.ToString()));
 				objLinkButton.CommandName = "SelectFile";
 				objLinkButton.CommandArgument = objItem.ItemId.ToString();
 				objLinkButton.EnableViewState = true;
-				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + objItem.Name.ToString());
+				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + WebUtility.HtmlEncode(objItem.Name.ToString()));
 				objPlaceHolder.Controls.Add(objLinkButton);
 				objLinkButton.ToolTip = Localization.GetString("ClickToVisit", LocalResourceFile);
 				objLinkButton.EnableViewState = true;
@@ -1053,12 +1054,12 @@ namespace DotNetNuke.Modules.Repository
 			if (!string.IsNullOrEmpty(objCategory.Category)) {
 				LinkButton objLinkButton = new LinkButton();
 				objLinkButton.ID = "hypDownload";
-				objLinkButton.Text = objCategory.Category.ToString();
+				objLinkButton.Text = WebUtility.HtmlEncode(objCategory.Category.ToString());
 				objLinkButton.CssClass = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "CssClass", "SubHead");
 				objLinkButton.CommandName = "SelectCategory";
 				objLinkButton.CommandArgument = objCategory.ItemId.ToString();
 				objLinkButton.EnableViewState = true;
-				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + " " + objCategory.Category.ToString());
+				objLinkButton.ToolTip = oRepositoryBusinessController.GetSkinAttribute(xmlDoc, "CATEGORY", "ToolTip", Localization.GetString("ClickToView", LocalResourceFile) + " " + WebUtility.HtmlEncode(objCategory.Category.ToString()));
 				objPlaceHolder.Controls.Add(objLinkButton);
 			}
 		}

--- a/Settings.ascx.cs
+++ b/Settings.ascx.cs
@@ -1374,8 +1374,8 @@ namespace DotNetNuke.Modules.Repository
                 if (lbAddCategory.Text == Localization.GetString("SaveButton", LocalResourceFile))
                 {
                     category = categories.GetSingleRepositoryCategory(_key);
-                    categories.UpdateRepositoryCategory(_key, WebUtility.HtmlEncode(txtNewCategory.Text.Trim()), _parent, category.ViewOrder);
-                    lstCategories.Items[_index].Text = WebUtility.HtmlEncode(txtNewCategory.Text.Trim());
+                    categories.UpdateRepositoryCategory(_key, HtmlUtils.StripTags(txtNewCategory.Text.Trim(), false), _parent, category.ViewOrder);
+                    lstCategories.Items[_index].Text = HtmlUtils.StripTags(txtNewCategory.Text.Trim(), false);
                     txtNewCategory.Text = "";
                     lbAddCategory.Text = Localization.GetString("AddCategory", LocalResourceFile);
                     lbCancelCategory.Visible = false;
@@ -1383,9 +1383,9 @@ namespace DotNetNuke.Modules.Repository
                 else
                 {
                     int dNewCatId = 0;
-                    dNewCatId = categories.AddRepositoryCategory(-1, ModuleId, WebUtility.HtmlEncode(txtNewCategory.Text.Trim()), _parent, 99);
+                    dNewCatId = categories.AddRepositoryCategory(-1, ModuleId, HtmlUtils.StripTags(txtNewCategory.Text.Trim(), false), _parent, 99);
                     ListItem objListItem = new ListItem();
-                    objListItem.Text = WebUtility.HtmlEncode(txtNewCategory.Text.Trim());
+                    objListItem.Text = HtmlUtils.StripTags(txtNewCategory.Text.Trim(), false);
                     objListItem.Value = dNewCatId.ToString();
                     lstCategories.Items.Add(objListItem);
                     txtNewCategory.Text = "";
@@ -1425,7 +1425,7 @@ namespace DotNetNuke.Modules.Repository
                 if (lbAddAttribute.Text == Localization.GetString("SaveButton", LocalResourceFile))
                 {
                     attribute = attributes.GetSingleRepositoryAttributes(_key);
-                    attribute.AttributeName = WebUtility.HtmlEncode(txtNewAttribute.Text.Trim());
+                    attribute.AttributeName = HtmlUtils.StripTags(txtNewAttribute.Text.Trim(), false);
                     RepositoryAttributesController.UpdateRepositoryAttributes(attribute);
                     lstAttributes.Items[_index].Text = attribute.AttributeName;
                     txtNewAttribute.Text = "";
@@ -1436,7 +1436,7 @@ namespace DotNetNuke.Modules.Repository
                 {
                     int dNewAttrId = 0;
                     attribute = new RepositoryAttributesInfo();
-                    attribute.AttributeName = WebUtility.HtmlEncode(txtNewAttribute.Text.Trim());
+                    attribute.AttributeName = HtmlUtils.StripTags(txtNewAttribute.Text.Trim(), false);
                     attribute.ModuleID = ModuleId;
                     dNewAttrId = attributes.AddRepositoryAttributes(attribute);
                     ListItem objListItem = new ListItem();
@@ -1469,7 +1469,7 @@ namespace DotNetNuke.Modules.Repository
                 if (lbAddValue.Text == Localization.GetString("SaveButton", LocalResourceFile))
                 {
                     attributeValue = attributeValues.GetSingleRepositoryAttributeValues(_key);
-                    attributeValue.ValueName = WebUtility.HtmlEncode(txtNewValue.Text.Trim());
+                    attributeValue.ValueName = HtmlUtils.StripTags(txtNewValue.Text.Trim(), false);
                     RepositoryAttributeValuesController.UpdateRepositoryAttributeValues(attributeValue);
                     lstValues.Items[_index].Text = attributeValue.ValueName;
                     txtNewValue.Text = "";
@@ -1481,7 +1481,7 @@ namespace DotNetNuke.Modules.Repository
                     int dNewAttrId = 0;
                     attributeValue = new RepositoryAttributeValuesInfo();
                     attributeValue.AttributeID = Convert.ToInt32(lstAttributes.SelectedValue);
-                    attributeValue.ValueName = WebUtility.HtmlEncode(txtNewValue.Text.Trim());
+                    attributeValue.ValueName = HtmlUtils.StripTags(txtNewValue.Text.Trim(), false);
                     dNewAttrId = attributeValues.AddRepositoryAttributeValues(attributeValue);
                     ListItem objListItem = new ListItem();
                     objListItem.Text = attributeValue.ValueName;


### PR DESCRIPTION
Closes #93 

@stetard FYI

This is a classic issue of double encoding.

There are generally 2 parts to preventing XSS.
1. Going from user input to the database should keep the normal raw formatting but sanitize the input to remove anything unexpected. In the case of normal strings like names and titles, that can be done with `HtmlUtils.StripTags` which will remove any html/script tags and only return a plain string without any tags. For html content it is a bit more complex and I will explain later.
2. Encoding is the responsibility of the piece of code that deals with displaying that string, in this case we are dealing with webforms that goes directly into html, so we can use HtmlEncode, but that data could be exposed in json in a webapi or other mechanisms that might need different handling (hence why it is best practice to only sanitize and not encode in the database).

Now for html content is is slightly different:
We don't want to remove all tags but still sanitize for no scripts. There is a method for that in `HtmlUtils.SanitizeHtmlIfNeeded`.
I will merge this and do a new beta if you have existing data you can test this out with.